### PR TITLE
Fix: Edit Type Error fixed

### DIFF
--- a/app.py
+++ b/app.py
@@ -54,9 +54,14 @@ def update_contact(id):
         contact.name = form.name.data
         contact.phone = form.phone.data
         contact.email = form.email.data
-        db.session.commit()
-        return redirect(url_for('list_contacts'))
-    
+        contact.type = form.type.data
+        try:
+            db.session.commit()
+            flash('Contact updated successfully!', 'success')
+            return redirect(url_for('list_contacts'))
+        except Exception as e:
+            db.session.rollback()
+            flash('Error updating contact.', 'error')
     return render_template('update_contact.html', form=form, contact=contact)
 
 @app.route('/delete/<int:id>')


### PR DESCRIPTION
The "Type" option had a bug where it would not update the contact despite the submit button being pressed.
The issue was the line: "contact.type = form.type.data" was missing in the update_contact, hence all the other fields would be updated except the "Type" field.

fix:
contact.type = form.type.data
was added in the update_contact on line 57

A message was also added to indicate the user that the contact has been updated.