### PR TITLE
Fix: Search Bar

### DIFF
--- a/templates/contacts.html
+++ b/templates/contacts.html
@@ -31,4 +31,5 @@
         {% endfor %}
     </tbody>
 </table>
+<script src="{{ url_for('static', filename='js/search.js')}}"></script>
 {% endblock %} 


### PR DESCRIPTION
The search bar had an error, it did not work when the user tries to search a contact.
The contacts.html file was not linked to the search.js, hence nothing happened when the user enters a contact.

Fix:
the search.js file was linked via a script tag