### PR TITLE
Fix: email input validation

### DIFF
--- a/forms.py
+++ b/forms.py
@@ -1,10 +1,11 @@
 from flask_wtf import FlaskForm
 from wtforms import StringField, SelectField, SubmitField
+from wtforms.validators import DataRequired, Email, ValidationError
 
 class ContactForm(FlaskForm):
     name = StringField('Name')
     phone = StringField('Phone')
-    email = StringField('Email')
+    email = StringField('Email', validators=[DataRequired(), Email()])
     type = SelectField('Type', 
                       choices=[('Personal', 'Personal'), 
                               ('Work', 'Work'), 


### PR DESCRIPTION
A validation has been added to the email field in the contact form, now users are required to enter a valid email with the format: "Email@example.com" and cannot submit the form with an empty field.

Fix:
utilizing: Email() and DataRequired() as validators from wtforms.validators in the file forms.py